### PR TITLE
Fix search region first char off-by-one

### DIFF
--- a/html_ui/Pms50/Pages/VCockpit/Instruments/NavSystems/Shared/LogicElements/SearchField.js
+++ b/html_ui/Pms50/Pages/VCockpit/Instruments/NavSystems/Shared/LogicElements/SearchField.js
@@ -88,7 +88,7 @@ class SearchFieldWaypointICAO {
             if(this.firstUpdate) {
                 currICAO = this.region;
                 if(currICAO.length) {
-                    var numiterations = currICAO.charCodeAt(0) - 65 + 10 + this.entryType;
+                    var numiterations = currICAO.charCodeAt(0) - 65 + 10 + 1 + this.entryType;
                     for(var i=0; i<numiterations; i++)
                         this.AdvanceCharacterNext();
                     if(currICAO.length > 1) {


### PR DESCRIPTION
When entering the second airport, the first character of the region code is off by one, eg. After entering LHTL as the first waypoint, when entering the next the search field has KH instead of the proper region code LH. This is broken since at least SU6 in every aircraft.